### PR TITLE
Fix LoginKey (3FA) auth — append ?key= to login and WebSocket URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,34 @@ The card shows online/offline status, OS, IP, logged-in users, last boot, securi
 
 Go to **Settings → Devices & Services → Add Integration → MeshCentral** and enter:
 
-FieldDescriptionHostIP or hostname of your MeshCentral serverPortDefault: 443UsernameMeshCentral usernamePasswordMeshCentral passwordUse SSLEnable for HTTPS/WSS (default: off)Verify SSLDisable if using self-signed cert (default: off)
+| Field | Description |
+|---|---|
+| Host | IP or hostname of your MeshCentral server |
+| Port | Default: 443 |
+| Username | MeshCentral username |
+| Password | MeshCentral password |
+| Login Key | Server-level LoginKey for 3FA — leave empty if not used (see below) |
+| Use SSL | Enable for HTTPS/WSS (default: off) |
+| Verify SSL | Disable if using self-signed cert (default: off) |
 
 ### 2FA accounts
 
 If your account has two-factor authentication enabled, create a **Login Token** in MeshCentral → My Account → Login Tokens. Use the generated username (`~t:...`) and password as credentials in HA — this bypasses 2FA entirely.
+
+### LoginKey (3FA) — server-level access key
+
+Some MeshCentral servers are configured with a **LoginKey** in `config.json`. This is a server-level 3FA feature that requires all requests — including the login page itself — to include a `?key=<value>` query parameter. Without it, the server blocks access before any authentication can occur.
+
+If your server uses this, you will see an auth failure even with correct username and password. Enter the LoginKey value in the **Login Key** field during setup.
+
+> **LoginKey vs Login Token — these are two different things:**
+>
+> | | What it is | Where to find it | Used as |
+> |---|---|---|---|
+> | **Login Key** (3FA) | Server-level URL access key | `config.json` → run server with `--logintokenkey` | The *Login Key* field in this integration |
+> | **Login Token** (2FA bypass) | Per-user temporary token | MeshCentral → My Account → Login Tokens | The *Username* field (as `~t:...`) |
+>
+> You may need both at the same time if your server uses LoginKey AND your account has 2FA enabled.
 
 ### TLS offload / reverse proxy
 
@@ -142,15 +165,14 @@ automation:
     to: "off"
   action:
     service: notify.mobile_app
-```
-
-data: message: "⚠️ Windows Defender disabled on ASUS-GamerPC!"
-
-```
+    data:
+      message: "⚠️ Windows Defender disabled on ASUS-GamerPC!"
 
 # Run a command on a device
-
-service: meshcentral.run_command data: device_id: fedora command: "systemctl restart nginx"
+service: meshcentral.run_command
+data:
+  device_id: fedora
+  command: "systemctl restart nginx"
 ```
 
 ## Related
@@ -162,27 +184,3 @@ service: meshcentral.run_command data: device_id: fedora command: "systemctl res
 ## License
 
 MIT
-
-```
-```
-
-```
-```
-
-```
-```
-
-```
-```
-
-```
-```
-
-```
-```
-
-```
-```
-
-```
-```

--- a/custom_components/meshcentral/client.py
+++ b/custom_components/meshcentral/client.py
@@ -60,11 +60,13 @@ class MeshCentralClient:
 
     @property
     def base_url(self) -> str:
+        """Base URL without path — used for constructing endpoint URLs."""
         scheme = "https" if self._use_ssl else "http"
-        return f"{scheme}://{self._host}:{self._port}{self._key_param}"
+        return f"{scheme}://{self._host}:{self._port}"
 
     @property
     def ws_url(self) -> str:
+        """WebSocket URL for /control.ashx, with optional ?key= after the path."""
         # Use ws:// even on port 443 when tlsOffload=true
         scheme = "wss" if self._use_ssl else "ws"
         return f"{scheme}://{self._host}:{self._port}{WS_CONTROL_PATH}{self._key_param}"
@@ -88,7 +90,7 @@ class MeshCentralClient:
         """Authenticate with MeshCentral and store session cookie."""
         session = await self._get_session()
         ssl_ctx = self._ssl_context()
-        login_url = f"{self.base_url}/login"
+        login_url = f"{self.base_url}/login{self._key_param}"
         payload = {"username": self._username, "password": self._password}
         _LOGGER.debug("Logging in to MeshCentral at %s", login_url)
         try:

--- a/custom_components/meshcentral/client.py
+++ b/custom_components/meshcentral/client.py
@@ -26,6 +26,11 @@ class MeshCentralClient:
     Note on tlsOffload: if MeshCentral runs behind a reverse proxy with
     tlsOffload=true, set use_ssl=False even if the port is 443. The server
     accepts plain HTTP/WS on that port while the proxy handles TLS externally.
+
+    Note on LoginKey (3FA): if the MeshCentral server has LoginKey enabled in
+    config.json, ALL requests (including login POST and WebSocket) must include
+    ?key=<loginkey> as a query parameter.  Pass the key via login_key here.
+    This is separate from per-user Login Tokens (~t:... username format).
     """
 
     def __init__(
@@ -36,6 +41,7 @@ class MeshCentralClient:
         password: str,
         use_ssl: bool = True,
         verify_ssl: bool = True,
+        login_key: str | None = None,
     ) -> None:
         self._host = host
         self._port = port
@@ -43,19 +49,25 @@ class MeshCentralClient:
         self._password = password
         self._use_ssl = use_ssl
         self._verify_ssl = verify_ssl
+        self._login_key = login_key or None
         self._session: aiohttp.ClientSession | None = None
         self._cookie: str | None = None
 
     @property
+    def _key_param(self) -> str:
+        """Return ?key=<loginkey> query string if LoginKey (3FA) is configured."""
+        return f"?key={self._login_key}" if self._login_key else ""
+
+    @property
     def base_url(self) -> str:
         scheme = "https" if self._use_ssl else "http"
-        return f"{scheme}://{self._host}:{self._port}"
+        return f"{scheme}://{self._host}:{self._port}{self._key_param}"
 
     @property
     def ws_url(self) -> str:
         # Use ws:// even on port 443 when tlsOffload=true
         scheme = "wss" if self._use_ssl else "ws"
-        return f"{scheme}://{self._host}:{self._port}{WS_CONTROL_PATH}"
+        return f"{scheme}://{self._host}:{self._port}{WS_CONTROL_PATH}{self._key_param}"
 
     def _ssl_context(self) -> ssl.SSLContext | bool:
         if not self._use_ssl:
@@ -198,11 +210,11 @@ class MeshCentralClient:
         return result is not None
 
     async def send_wol(self, node_id: str) -> str | None:
-        """Send Wake-on-LAN via MeshCentral's wakedevices action.
+        """Send Wake-on-LAN via MeshCentral wakedevices action.
 
         MeshCentral finds all online agents on the same network and uses
         them to broadcast the WOL magic packet to the target device.
-        Returns a result string like 'Used 2 device(s) to send wake packets'
+        Returns a result string like "Used 2 device(s) to send wake packets"
         or None on failure.
         """
         result = await self._send_recv(
@@ -223,9 +235,6 @@ class MeshCentralClient:
         """Run a shell command on a device via MeshCentral agent.
 
         Returns command output as string, or None on timeout/failure.
-        Note: MeshCentral runs the command asynchronously — the response
-        contains a runid which can be used to track the result. We wait
-        up to WS_TIMEOUT seconds for the result to come back.
         """
         result = await self._send_recv(
             {

--- a/custom_components/meshcentral/config_flow.py
+++ b/custom_components/meshcentral/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 
 from .client import MeshCentralClient
-from .const import CONF_USE_SSL, CONF_VERIFY_SSL, DEFAULT_PORT, DOMAIN
+from .const import CONF_LOGIN_KEY, CONF_USE_SSL, CONF_VERIFY_SSL, DEFAULT_PORT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,6 +20,7 @@ STEP_USER_SCHEMA = vol.Schema(
         vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_LOGIN_KEY, default=""): str,
         vol.Optional(CONF_USE_SSL, default=False): bool,
         vol.Optional(CONF_VERIFY_SSL, default=False): bool,
     }
@@ -37,6 +38,7 @@ class MeshCentralConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            login_key = user_input.get(CONF_LOGIN_KEY) or None
             client = MeshCentralClient(
                 host=user_input[CONF_HOST],
                 port=user_input[CONF_PORT],
@@ -44,6 +46,7 @@ class MeshCentralConfigFlow(ConfigFlow, domain=DOMAIN):
                 password=user_input[CONF_PASSWORD],
                 use_ssl=user_input.get(CONF_USE_SSL, False),
                 verify_ssl=user_input.get(CONF_VERIFY_SSL, False),
+                login_key=login_key,
             )
             try:
                 ok = await client.login()

--- a/custom_components/meshcentral/const.py
+++ b/custom_components/meshcentral/const.py
@@ -4,6 +4,7 @@ DOMAIN = "meshcentral"
 
 CONF_USE_SSL = "use_ssl"
 CONF_VERIFY_SSL = "verify_ssl"
+CONF_LOGIN_KEY = "login_key"
 
 DEFAULT_PORT = 443
 DEFAULT_USE_SSL = False

--- a/custom_components/meshcentral/coordinator.py
+++ b/custom_components/meshcentral/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .client import MeshCentralClient
 from .const import (
+    CONF_LOGIN_KEY,
     CONF_USE_SSL,
     CONF_VERIFY_SSL,
     DEFAULT_SCAN_INTERVAL,
@@ -48,6 +49,7 @@ class MeshCentralCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             password=entry.data[CONF_PASSWORD],
             use_ssl=entry.data.get(CONF_USE_SSL, False),
             verify_ssl=entry.data.get(CONF_VERIFY_SSL, False),
+            login_key=entry.data.get(CONF_LOGIN_KEY) or None,
         )
         self._logged_in = False
         self._event_task: asyncio.Task | None = None
@@ -144,7 +146,6 @@ class MeshCentralCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.data[node_id].get("name", node_id),
                         evt.get("conn"),
                     )
-                    # Only update if we have valid data
                     if self.data:
                         self.async_set_updated_data(dict(self.data))
 

--- a/custom_components/meshcentral/manifest.json
+++ b/custom_components/meshcentral/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "meshcentral",
   "name": "MeshCentral",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "documentation": "https://github.com/andlo/ha-meshcentral",
   "issue_tracker": "https://github.com/andlo/ha-meshcentral/issues",
   "codeowners": ["@andlo"],

--- a/custom_components/meshcentral/strings.json
+++ b/custom_components/meshcentral/strings.json
@@ -9,14 +9,18 @@
           "port": "Port",
           "username": "Username",
           "password": "Password",
+          "login_key": "LoginKey (3FA) — leave empty if not used",
           "use_ssl": "Use SSL (disable if behind reverse proxy with tlsOffload)",
           "verify_ssl": "Verify SSL certificate"
+        },
+        "data_description": {
+          "login_key": "Server-level LoginKey for 3FA. If your MeshCentral config.json has LoginKey enabled, all requests must include this key. Find it by running the server with --logintokenkey. This is NOT the same as a per-user Login Token (~t:... username)."
         }
       }
     },
     "error": {
       "cannot_connect": "Cannot connect to MeshCentral server",
-      "invalid_auth": "Authentication failed — check username and password"
+      "invalid_auth": "Authentication failed — check username, password and LoginKey"
     },
     "abort": {
       "already_configured": "This MeshCentral server is already configured"


### PR DESCRIPTION
Fixes #12

## What

Adds support for MeshCentral servers with `LoginKey` (3FA) enabled. When active, the server requires `?key=<loginkey>` on all requests — including the initial login POST and the WebSocket connection. Without it, auth always fails before credentials are even checked.

## Changes

- **`const.py`** — new `CONF_LOGIN_KEY = "login_key"` constant
- **`client.py`** — optional `login_key` parameter; `_key_param` property appends `?key=` to `base_url` and `ws_url` when set
- **`config_flow.py`** — optional `Login Key` field in the setup form; passes value to client
- **`coordinator.py`** — reads `CONF_LOGIN_KEY` from config entry and passes to client
- **`strings.json`** — label + description for the new field, clarifying it is NOT the same as a per-user Login Token (`~t:...`)

## Notes

- The field is optional — users without `LoginKey` are unaffected
- `login_key` (server-level 3FA URL key) and Login Tokens (`~t:...` username) are independent; both may be needed simultaneously
- Reported by @michaelmikelas in [Ylianst/MeshCentral#7770](https://github.com/Ylianst/MeshCentral/discussions/7770#discussioncomment-17019888)

## Testing needed

Needs verification on a real MeshCentral server with `LoginKey` configured. See issue #12 for details.