### PR TITLE
Fix devices briefly showing offline on WS reconnect

### DIFF
--- a/custom_components/meshcentral/coordinator.py
+++ b/custom_components/meshcentral/coordinator.py
@@ -115,6 +115,7 @@ class MeshCentralCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             timeout=aiohttp.ClientTimeout(total=None),  # keep-alive forever
         ) as ws:
             _LOGGER.debug("MeshCentral event WS connected")
+            await self._refresh_after_reconnect()
             while True:
                 msg = await ws.receive()
                 if msg.type == aiohttp.WSMsgType.TEXT:
@@ -125,6 +126,28 @@ class MeshCentralCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 ):
                     _LOGGER.debug("MeshCentral event WS closed, reconnecting")
                     break
+
+    async def _refresh_after_reconnect(self) -> None:
+        """Poll the full device list right after a WS (re)connect.
+
+        The WebSocket only pushes deltas for devices that change state, so a
+        client that reconnects after a drop (e.g. after sending a WOL command)
+        can otherwise sit with stale/incomplete data until the 5-minute
+        fallback poll runs, causing devices to briefly appear offline. This
+        closes that gap by fetching a fresh full list immediately.
+        """
+        try:
+            devices = await self.client.get_devices()
+        except Exception as err:
+            _LOGGER.warning("MeshCentral post-reconnect poll failed: %s", err)
+            return
+
+        data = {d["_id"]: d for d in devices if "_id" in d}
+        if data:
+            self.async_set_updated_data(data)
+            _LOGGER.debug(
+                "MeshCentral post-reconnect poll refreshed %d devices", len(data)
+            )
 
     async def _handle_event(self, data: dict) -> None:
         """Process a single WebSocket message and update coordinator data."""

--- a/custom_components/meshcentral/manifest.json
+++ b/custom_components/meshcentral/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "meshcentral",
   "name": "MeshCentral",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "documentation": "https://github.com/andlo/ha-meshcentral",
   "issue_tracker": "https://github.com/andlo/ha-meshcentral/issues",
   "codeowners": ["@andlo"],


### PR DESCRIPTION
Closes #8.

Adds a full `get_devices()` poll immediately after the WebSocket (re)connects, so the coordinator's data is guaranteed fresh and complete instead of waiting on the 5-minute fallback poll. This was the missing piece noted in #8 — the `if self.data` guard was already in place, this adds the reconnect poll.