### PR TITLE
Add power state sensor (on/off/sleep/hibernate/soft-off/cycle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Running MeshCentral alongside Home Assistant is a powerful combination for anyon
 
 ### Per device — Status sensors
 
-EntityDescription`binary_sensor.<n>_online`Agent connectivity (online/offline) — real-time`sensor.<n>_os`OS description`sensor.<n>_ip_address`Last known IP address`sensor.<n>_last_boot`Last boot time (timestamp)`sensor.<n>_idle_time`User idle time in seconds`sensor.<n>_active_users`Currently logged-in users`sensor.<n>_description`Device description from MeshCentral`sensor.<n>_agent_last_seen`When agent last contacted server`device_tracker.<n>_tracker`Home/not_home based on agent connectivity
+EntityDescription`binary_sensor.<n>_online`Agent connectivity (online/offline) — real-time`sensor.<n>_os`OS description`sensor.<n>_ip_address`Last known IP address`sensor.<n>_last_boot`Last boot time (timestamp)`sensor.<n>_idle_time`User idle time in seconds`sensor.<n>_active_users`Currently logged-in users`sensor.<n>_description`Device description from MeshCentral`sensor.<n>_agent_last_seen`When agent last contacted server`sensor.<n>_power_state`Power state: on / off / sleep / hibernate / soft_off / cycle`device_tracker.<n>_tracker`Home/not_home based on agent connectivity
 
 ### Per device — Security (Windows only)
 

--- a/custom_components/meshcentral/const.py
+++ b/custom_components/meshcentral/const.py
@@ -20,3 +20,15 @@ ATTR_AGENT_VERSION = "agent_version"
 ATTR_IP_ADDRESS = "ip_address"
 ATTR_LAST_CONNECT = "last_connect"
 ATTR_POWER_STATE = "power_state"
+
+# Mapping of MeshCentral's numeric "pwr" node field to a human-readable state.
+# See: https://github.com/Ylianst/MeshCentral (nodeconnect / node "pwr" field)
+POWER_STATE_MAP = {
+    0: "off",
+    1: "on",
+    2: "sleep",
+    3: "hibernate",
+    4: "soft_off",
+    5: "cycle",
+}
+POWER_STATE_UNKNOWN = "unknown"

--- a/custom_components/meshcentral/sensor.py
+++ b/custom_components/meshcentral/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, POWER_STATE_MAP, POWER_STATE_UNKNOWN
 from .coordinator import MeshCentralCoordinator
 from .sensor_hardware import HardwareDataCoordinator, async_setup_hardware_entities
 
@@ -32,6 +32,7 @@ async def async_setup_entry(
             MeshCentralUsersSensor(coordinator, node_id),
             MeshCentralDescSensor(coordinator, node_id),
             MeshCentralAgentLastSeenSensor(coordinator, node_id),
+            MeshCentralPowerStateSensor(coordinator, node_id),
         ]
     async_add_entities(entities)
 
@@ -168,3 +169,27 @@ class MeshCentralAgentLastSeenSensor(_Base):
         if ts:
             return datetime.fromtimestamp(ts / 1000, tz=timezone.utc)
         return None
+
+
+class MeshCentralPowerStateSensor(_Base):
+    """Power state (on/off/sleep/hibernate/soft-off/cycle) for a device.
+
+    MeshCentral reports this via the numeric "pwr" field on the node and in
+    "nodeconnect" WebSocket events. See const.POWER_STATE_MAP for the mapping.
+    """
+
+    _attr_name = "Power State"
+    _attr_icon = "mdi:power-settings"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = list(POWER_STATE_MAP.values()) + [POWER_STATE_UNKNOWN]
+
+    def __init__(self, coordinator, node_id):
+        super().__init__(coordinator, node_id)
+        self._attr_unique_id = f"mc_{node_id}_pwr"
+
+    @property
+    def native_value(self):
+        pwr = self._node.get("pwr")
+        if pwr is None:
+            return POWER_STATE_UNKNOWN
+        return POWER_STATE_MAP.get(pwr, POWER_STATE_UNKNOWN)


### PR DESCRIPTION
Closes #2

Adds `sensor.<name>_power_state`, mapping MeshCentral's numeric `pwr` node field to a human-readable state:

- 0 = off
- 1 = on
- 2 = sleep
- 3 = hibernate
- 4 = soft_off
- 5 = cycle

Uses `SensorDeviceClass.ENUM` with the mapped values as `options`. Falls back to `unknown` if `pwr` hasn't been reported yet (it's populated via `nodeconnect` WebSocket events, same as the existing `conn` handling).

Also updated README's status sensor table.