### PR TITLE
Support multiple disk volumes (beyond C: / root)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ EntityDescription`sensor.<n>_cpu`CPU model name`sensor.<n>_gpu`GPU model name`se
 
 EntityDescription`sensor.<n>_ram_total`Total RAM in GB`sensor.<n>_disk_c_total`C: drive total size in GB`sensor.<n>_disk_c_free`C: drive free space in GB`sensor.<n>_disk_c_free_percent`C: drive free space in %`sensor.<n>_running_processes`Number of running processes`sensor.<n>_screen_resolution`Current screen resolution (e.g. 1920x1080)
 
+Additional volumes beyond C: (D:, E:, ...) get their own set of Total/Free/Free % sensors automatically, named after the drive letter.
+
 **Linux only:**
 
 EntityDescription`sensor.<n>_disk_used`Root filesystem used in MB`sensor.<n>_disk_free`Root filesystem free in MB
+
+Additional mount points beyond / (e.g. /home, /mnt/data) get their own Used/Free sensors automatically, named after the mount point.
 
 ### Service
 

--- a/custom_components/meshcentral/sensor_hardware.py
+++ b/custom_components/meshcentral/sensor_hardware.py
@@ -27,6 +27,18 @@ from .coordinator import MeshCentralCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+def _win_volume_slug(drive_letter: str) -> str:
+    """Turn a Windows drive letter (e.g. 'D') into an entity-id-safe slug."""
+    return drive_letter.strip().rstrip(":").lower()
+
+
+def _linux_mount_slug(mount_point: str) -> str:
+    """Turn a Linux mount point (e.g. '/home') into an entity-id-safe slug."""
+    if mount_point in ("/", ""):
+        return "root"
+    return mount_point.strip("/").replace("/", "_").lower() or "root"
+
+
 class HardwareDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator that fetches getsysinfo for all online devices every 5 min."""
 
@@ -88,19 +100,37 @@ async def async_setup_hardware_entities(
         if is_windows:
             entities += [
                 RamTotalSensor(hw_coordinator, main, node_id),
-                DiskTotalSensor(hw_coordinator, main, node_id),
-                DiskFreeSensor(hw_coordinator, main, node_id),
-                DiskFreePercentSensor(hw_coordinator, main, node_id),
                 ProcessCountSensor(hw_coordinator, main, node_id),
                 ScreenResolutionSensor(hw_coordinator, main, node_id),
             ]
+            win_volumes = hw.get("windows", {}).get("volumes", {})
+            if win_volumes:
+                for drive_letter in win_volumes:
+                    entities += [
+                        WindowsDiskTotalSensor(hw_coordinator, main, node_id, drive_letter),
+                        WindowsDiskFreeSensor(hw_coordinator, main, node_id, drive_letter),
+                        WindowsDiskFreePercentSensor(hw_coordinator, main, node_id, drive_letter),
+                    ]
+            else:
+                # No sysinfo fetched yet for this device — fall back to the
+                # C: drive so entities still get created on first setup.
+                entities += [
+                    WindowsDiskTotalSensor(hw_coordinator, main, node_id, "C"),
+                    WindowsDiskFreeSensor(hw_coordinator, main, node_id, "C"),
+                    WindowsDiskFreePercentSensor(hw_coordinator, main, node_id, "C"),
+                ]
 
         # Linux
         if is_linux:
-            entities += [
-                LinuxDiskUsedSensor(hw_coordinator, main, node_id),
-                LinuxDiskFreeSensor(hw_coordinator, main, node_id),
-            ]
+            linux_volumes = hw.get("linux", {}).get("volumes", [])
+            mount_points = [v.get("mount_point") for v in linux_volumes if v.get("mount_point")]
+            if not mount_points:
+                mount_points = ["/"]
+            for mount_point in mount_points:
+                entities += [
+                    LinuxDiskUsedSensor(hw_coordinator, main, node_id, mount_point),
+                    LinuxDiskFreeSensor(hw_coordinator, main, node_id, mount_point),
+                ]
 
     async_add_entities(entities)
 
@@ -252,55 +282,71 @@ class RamTotalSensor(_HwBase):
         return round(total / (1024 ** 3), 1) if total else None
 
 
-class DiskTotalSensor(_HwBase):
-    _attr_name = "Disk C: Total"
+class WindowsDiskTotalSensor(_HwBase):
     _attr_icon = "mdi:harddisk"
     _attr_native_unit_of_measurement = UnitOfInformation.GIGABYTES
     _attr_device_class = SensorDeviceClass.DATA_SIZE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, coordinator, main, node_id):
+    def __init__(self, coordinator, main, node_id, drive_letter: str):
         super().__init__(coordinator, main, node_id)
-        self._attr_unique_id = f"mc_{node_id}_hw_disk_total"
+        self._drive_letter = drive_letter
+        self._attr_name = f"Disk {drive_letter}: Total"
+        if drive_letter.upper() == "C":
+            # Keep the original unique_id for backwards compatibility.
+            self._attr_unique_id = f"mc_{node_id}_hw_disk_total"
+        else:
+            slug = _win_volume_slug(drive_letter)
+            self._attr_unique_id = f"mc_{node_id}_hw_disk_{slug}_total"
 
     @property
     def native_value(self):
-        vol = self._win.get("volumes", {}).get("C", {})
+        vol = self._win.get("volumes", {}).get(self._drive_letter, {})
         size = vol.get("size", 0)
         return round(size / (1024 ** 3), 1) if size else None
 
 
-class DiskFreeSensor(_HwBase):
-    _attr_name = "Disk C: Free"
+class WindowsDiskFreeSensor(_HwBase):
     _attr_icon = "mdi:harddisk"
     _attr_native_unit_of_measurement = UnitOfInformation.GIGABYTES
     _attr_device_class = SensorDeviceClass.DATA_SIZE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, coordinator, main, node_id):
+    def __init__(self, coordinator, main, node_id, drive_letter: str):
         super().__init__(coordinator, main, node_id)
-        self._attr_unique_id = f"mc_{node_id}_hw_disk_free"
+        self._drive_letter = drive_letter
+        self._attr_name = f"Disk {drive_letter}: Free"
+        if drive_letter.upper() == "C":
+            self._attr_unique_id = f"mc_{node_id}_hw_disk_free"
+        else:
+            slug = _win_volume_slug(drive_letter)
+            self._attr_unique_id = f"mc_{node_id}_hw_disk_{slug}_free"
 
     @property
     def native_value(self):
-        vol = self._win.get("volumes", {}).get("C", {})
+        vol = self._win.get("volumes", {}).get(self._drive_letter, {})
         free = vol.get("sizeremaining", 0)
         return round(free / (1024 ** 3), 1) if free else None
 
 
-class DiskFreePercentSensor(_HwBase):
-    _attr_name = "Disk C: Free %"
+class WindowsDiskFreePercentSensor(_HwBase):
     _attr_icon = "mdi:harddisk"
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, coordinator, main, node_id):
+    def __init__(self, coordinator, main, node_id, drive_letter: str):
         super().__init__(coordinator, main, node_id)
-        self._attr_unique_id = f"mc_{node_id}_hw_disk_pct"
+        self._drive_letter = drive_letter
+        self._attr_name = f"Disk {drive_letter}: Free %"
+        if drive_letter.upper() == "C":
+            self._attr_unique_id = f"mc_{node_id}_hw_disk_pct"
+        else:
+            slug = _win_volume_slug(drive_letter)
+            self._attr_unique_id = f"mc_{node_id}_hw_disk_{slug}_pct"
 
     @property
     def native_value(self):
-        vol = self._win.get("volumes", {}).get("C", {})
+        vol = self._win.get("volumes", {}).get(self._drive_letter, {})
         size = vol.get("size", 0)
         free = vol.get("sizeremaining", 0)
         if size and free:
@@ -345,40 +391,51 @@ class ScreenResolutionSensor(_HwBase):
 # ── Linux sensors ──────────────────────────────────────────────────────────────
 
 class LinuxDiskUsedSensor(_HwBase):
-    _attr_name = "Disk / Used"
     _attr_icon = "mdi:harddisk"
     _attr_native_unit_of_measurement = UnitOfInformation.MEGABYTES
     _attr_device_class = SensorDeviceClass.DATA_SIZE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, coordinator, main, node_id):
+    def __init__(self, coordinator, main, node_id, mount_point: str):
         super().__init__(coordinator, main, node_id)
-        self._attr_unique_id = f"mc_{node_id}_hw_linux_disk_used"
+        self._mount_point = mount_point
+        self._attr_name = f"Disk {mount_point} Used"
+        if mount_point == "/":
+            # Keep the original unique_id for backwards compatibility.
+            self._attr_unique_id = f"mc_{node_id}_hw_linux_disk_used"
+        else:
+            slug = _linux_mount_slug(mount_point)
+            self._attr_unique_id = f"mc_{node_id}_hw_linux_disk_{slug}_used"
 
     @property
     def native_value(self):
         for vol in self._linux.get("volumes", []):
-            if vol.get("mount_point") == "/":
+            if vol.get("mount_point") == self._mount_point:
                 used = vol.get("used", 0)
                 return round(int(used) / 1024, 1) if used else None
         return None
 
 
 class LinuxDiskFreeSensor(_HwBase):
-    _attr_name = "Disk / Free"
     _attr_icon = "mdi:harddisk"
     _attr_native_unit_of_measurement = UnitOfInformation.MEGABYTES
     _attr_device_class = SensorDeviceClass.DATA_SIZE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, coordinator, main, node_id):
+    def __init__(self, coordinator, main, node_id, mount_point: str):
         super().__init__(coordinator, main, node_id)
-        self._attr_unique_id = f"mc_{node_id}_hw_linux_disk_free"
+        self._mount_point = mount_point
+        self._attr_name = f"Disk {mount_point} Free"
+        if mount_point == "/":
+            self._attr_unique_id = f"mc_{node_id}_hw_linux_disk_free"
+        else:
+            slug = _linux_mount_slug(mount_point)
+            self._attr_unique_id = f"mc_{node_id}_hw_linux_disk_{slug}_free"
 
     @property
     def native_value(self):
         for vol in self._linux.get("volumes", []):
-            if vol.get("mount_point") == "/":
+            if vol.get("mount_point") == self._mount_point:
                 avail = vol.get("available", 0)
                 return round(int(avail) / 1024, 1) if avail else None
         return None


### PR DESCRIPTION
Closes #1

**Windows**: entities are now created for every drive letter present in `hardware.windows.volumes` (previously only `C:` was tracked). Each volume gets its own Total / Free / Free % sensor, e.g. `sensor.<name>_disk_d_total`.

**Linux**: entities are now created for every mount point present in `hardware.linux.volumes` (previously only `/` was tracked). Each mount gets its own Used / Free sensor, e.g. `sensor.<name>_disk_home_used`.

**Backwards compatibility**: the original `C:` and `/` sensors keep their exact original `unique_id` (`mc_<node>_hw_disk_total`, `mc_<node>_hw_disk_free`, `mc_<node>_hw_disk_pct`, `mc_<node>_hw_linux_disk_used`, `mc_<node>_hw_linux_disk_free`), so existing installs won't get orphaned entities or lose history/customizations. Only the *additional* volumes get new entity IDs.

**Note**: like the rest of the hardware sensors, the volume list is determined once at platform setup from the first `getsysinfo` call. A newly attached drive/mount won't get a sensor until HA restarts — same limitation the integration already has for Windows vs Linux detection.

Updated README to document this.