### PR TITLE
run_command: fire event, optional notification, and service response

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ EntityDescription`sensor.<n>_disk_used`Root filesystem used in MB`sensor.<n>_dis
 
 ServiceDescription`meshcentral.run_command`Run a shell command on any online device
 
+`run_command` always fires a `meshcentral_command_result` event with `device_id`, `device_name`, `command`, `success`, and `output`, and returns the same data as a service response (use `response_variable` in scripts/automations to capture it). Set `notify: true` to also create a persistent notification with the output.
+
 ## Installation
 
 ### Via HACS (recommended)
@@ -168,11 +170,22 @@ automation:
     data:
       message: "⚠️ Windows Defender disabled on ASUS-GamerPC!"
 
-# Run a command on a device
+# Run a command on a device and get a notification with the output
 service: meshcentral.run_command
 data:
   device_id: fedora
   command: "systemctl restart nginx"
+  notify: true
+
+# Or capture the result in a script/automation
+- service: meshcentral.run_command
+  data:
+    device_id: fedora
+    command: "uptime"
+  response_variable: cmd_result
+- service: notify.mobile_app
+  data:
+    message: "{{ cmd_result.output }}"
 ```
 
 ## Related

--- a/custom_components/meshcentral/services.py
+++ b/custom_components/meshcentral/services.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 import logging
 
 import voluptuous as vol
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.persistent_notification import async_create as async_create_notification
 
 from .const import DOMAIN
 from .coordinator import MeshCentralCoordinator
@@ -13,12 +14,14 @@ from .coordinator import MeshCentralCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 SERVICE_RUN_COMMAND = "run_command"
+EVENT_COMMAND_RESULT = "meshcentral_command_result"
 
 SERVICE_RUN_COMMAND_SCHEMA = vol.Schema(
     {
         vol.Required("device_id"): cv.string,
         vol.Required("command"): cv.string,
         vol.Optional("run_as_user", default=False): cv.boolean,
+        vol.Optional("notify", default=False): cv.boolean,
     }
 )
 
@@ -26,37 +29,62 @@ SERVICE_RUN_COMMAND_SCHEMA = vol.Schema(
 def async_register_services(hass: HomeAssistant) -> None:
     """Register MeshCentral services."""
 
-    async def handle_run_command(call: ServiceCall) -> None:
+    async def handle_run_command(call: ServiceCall) -> ServiceResponse:
         device_id = call.data["device_id"]
         command = call.data["command"]
         run_as_user = call.data.get("run_as_user", False)
+        notify = call.data.get("notify", False)
 
         # Find coordinator and node_id from device_id
         coordinator, node_id = _find_node(hass, device_id)
         if not coordinator or not node_id:
             _LOGGER.error("run_command: device '%s' not found in MeshCentral", device_id)
-            return
+            return {"success": False, "device": device_id, "command": command, "output": None}
 
         node = coordinator.data.get(node_id, {})
+        device_name = node.get("name", device_id)
+
         if node.get("conn", 0) != 1:
-            _LOGGER.warning(
-                "run_command: device '%s' is offline, command not sent", node.get("name")
-            )
-            return
+            _LOGGER.warning("run_command: device '%s' is offline, command not sent", device_name)
+            return {"success": False, "device": device_name, "command": command, "output": None}
 
         result = await coordinator.client.run_command(node_id, command, run_as_user)
-        if result is not None:
+        success = result is not None
+
+        if success:
             _LOGGER.info(
-                "run_command on '%s': %s", node.get("name"), result[:200] if result else "(no output)"
+                "run_command on '%s': %s", device_name, result[:200] if result else "(no output)"
             )
         else:
-            _LOGGER.warning("run_command on '%s' returned no response", node.get("name"))
+            _LOGGER.warning("run_command on '%s' returned no response", device_name)
+
+        hass.bus.async_fire(
+            EVENT_COMMAND_RESULT,
+            {
+                "device_id": node_id,
+                "device_name": device_name,
+                "command": command,
+                "success": success,
+                "output": result,
+            },
+        )
+
+        if notify:
+            async_create_notification(
+                hass,
+                f"Command: `{command}`\n\n```\n{result or '(no output)'}\n```",
+                title=f"MeshCentral: {device_name}",
+                notification_id=f"meshcentral_run_command_{node_id}",
+            )
+
+        return {"success": success, "device": device_name, "command": command, "output": result}
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_RUN_COMMAND,
         handle_run_command,
         schema=SERVICE_RUN_COMMAND_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
     )
 
 

--- a/custom_components/meshcentral/services.yaml
+++ b/custom_components/meshcentral/services.yaml
@@ -25,3 +25,12 @@ run_command:
       default: false
       selector:
         boolean:
+    notify:
+      name: Notify
+      description: >
+        Create a persistent notification in Home Assistant with the command output.
+        A "meshcentral_command_result" event is always fired regardless of this setting.
+      required: false
+      default: false
+      selector:
+        boolean:


### PR DESCRIPTION
Closes #3

`meshcentral.run_command` now surfaces its output beyond the HA log:

1. Always fires a `meshcentral_command_result` event on the bus with `device_id`, `device_name`, `command`, `success`, and `output`.
2. Returns the same payload as a service response (`supports_response=SupportsResponse.OPTIONAL`), so it can be captured with `response_variable` in scripts/automations (HA 2023.7+).
3. New optional `notify: true` field creates a `persistent_notification` with the command output (off by default, since not everyone wants a popup for every command).

Updated `services.yaml` and README with the new field and usage examples.