### PR TITLE
Add server version sensors (installed + latest available)

### DIFF
--- a/custom_components/meshcentral/__init__.py
+++ b/custom_components/meshcentral/__init__.py
@@ -49,6 +49,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator: MeshCentralCoordinator = hass.data[DOMAIN].pop(entry.entry_id)
         await coordinator.async_shutdown()
         hass.data[DOMAIN].pop(f"{entry.entry_id}_hw", None)
+        hass.data[DOMAIN].pop(f"{entry.entry_id}_serverversion", None)
     return unload_ok
 
 

--- a/custom_components/meshcentral/client.py
+++ b/custom_components/meshcentral/client.py
@@ -177,6 +177,29 @@ class MeshCentralClient:
             return []
         return result.get("meshes", [])
 
+    async def get_server_version_tags(self) -> dict | None:
+        """Return the server's own version info, if this session is allowed to.
+
+        MeshCentral only answers the "serverversion" action for full site
+        administrators authenticated with a regular username/password login —
+        it is explicitly refused for sessions using a Login Token (the
+        "~t:..." username used to bypass 2FA), and requires the account's
+        "update" site-right. Returns None if unavailable for either reason;
+        callers should treat that as "unknown", not an error.
+
+        On success, the dict has a "current" key with the installed version,
+        and usually a "latest" key with the latest published version (from
+        the server's own npm dist-tag check) — but "latest" may be absent if
+        the server itself has no internet/npm access.
+        """
+        result = await self._send_recv(
+            {"action": "serverversion", "responseid": "ha-serverversion"},
+            "serverversion",
+        )
+        if result and isinstance(result.get("tags"), dict):
+            return result["tags"]
+        return None
+
     async def get_sysinfo(self, node_id: str) -> dict | None:
         """Return full hardware/sysinfo for a single device."""
         result = await self._send_recv(

--- a/custom_components/meshcentral/sensor.py
+++ b/custom_components/meshcentral/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, POWER_STATE_MAP, POWER_STATE_UNKNOWN
 from .coordinator import MeshCentralCoordinator
 from .sensor_hardware import HardwareDataCoordinator, async_setup_hardware_entities
+from .sensor_serverversion import async_setup_server_version_entities
 
 
 async def async_setup_entry(
@@ -41,6 +42,9 @@ async def async_setup_entry(
     await hw_coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][f"{entry.entry_id}_hw"] = hw_coordinator
     await async_setup_hardware_entities(hass, entry, coordinator, hw_coordinator, async_add_entities)
+
+    # Server-level version sensors (installed / latest available)
+    await async_setup_server_version_entities(hass, entry, coordinator, async_add_entities)
 
 
 class _Base(CoordinatorEntity[MeshCentralCoordinator], SensorEntity):

--- a/custom_components/meshcentral/sensor_serverversion.py
+++ b/custom_components/meshcentral/sensor_serverversion.py
@@ -1,0 +1,155 @@
+"""Server-level version sensors (installed vs. latest available)."""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+
+from .const import DOMAIN
+from .coordinator import MeshCentralCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+NPM_LATEST_URL = "https://registry.npmjs.org/meshcentral/latest"
+
+
+class ServerVersionCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Polls installed + latest available MeshCentral server version.
+
+    Slow interval by design — server versions change rarely, and one branch
+    of this check is an external HTTPS call to the npm registry that
+    shouldn't run on every device poll.
+    """
+
+    def __init__(self, hass: HomeAssistant, main: MeshCentralCoordinator) -> None:
+        super().__init__(
+            hass, _LOGGER,
+            name=f"{DOMAIN}_serverversion",
+            update_interval=timedelta(hours=6),
+        )
+        self._main = main
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        data: dict[str, Any] = {"installed": None, "latest": None}
+
+        # Best case: the server tells us directly (only works for full
+        # site-admins on a regular username/password login — see
+        # client.get_server_version_tags docstring).
+        tags = await self._main.client.get_server_version_tags()
+        if tags:
+            data["installed"] = tags.get("current")
+            if tags.get("latest"):
+                data["latest"] = tags["latest"]
+
+        # Always cross-check against npm directly too — this works for any
+        # server regardless of auth type or hosting, and is authoritative
+        # for "latest" even when the server-reported value above is missing
+        # or the server itself has no internet access to check npm.
+        try:
+            session = async_get_clientsession(self.hass)
+            async with session.get(NPM_LATEST_URL, timeout=10) as resp:
+                if resp.status == 200:
+                    npm_data = await resp.json(content_type=None)
+                    npm_version = npm_data.get("version")
+                    if npm_version:
+                        data["latest"] = npm_version
+        except Exception as err:  # noqa: BLE001 - never let this break device polling
+            _LOGGER.debug("npm registry version check failed: %s", err)
+
+        return data
+
+
+async def async_setup_server_version_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    main: MeshCentralCoordinator,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = ServerVersionCoordinator(hass, main)
+    await coordinator.async_config_entry_first_refresh()
+    hass.data[DOMAIN][f"{entry.entry_id}_serverversion"] = coordinator
+
+    async_add_entities([
+        MeshCentralInstalledVersionSensor(coordinator, main, entry.entry_id),
+        MeshCentralLatestVersionSensor(coordinator, main, entry.entry_id),
+    ])
+
+
+class _ServerBase(CoordinatorEntity[ServerVersionCoordinator], SensorEntity):
+    """Base for server-level (not per-device) sensors.
+
+    These live on a synthetic "MeshCentral Server" device, separate from the
+    per-node devices, since they describe the server itself.
+    """
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: ServerVersionCoordinator, main: MeshCentralCoordinator, entry_id: str) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._main = main
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, f"{self._entry_id}_server")},
+            "name": "MeshCentral Server",
+            "manufacturer": "MeshCentral",
+            "configuration_url": self._main.client.base_url,
+        }
+
+
+class MeshCentralInstalledVersionSensor(_ServerBase):
+    """Installed MeshCentral server version.
+
+    Only populated for full site-admin accounts logged in with a regular
+    username/password (not a Login Token / 2FA-bypass token — MeshCentral
+    itself refuses this check for those sessions). Otherwise stays unknown.
+    """
+
+    _attr_name = "Installed Version"
+    _attr_icon = "mdi:server"
+
+    def __init__(self, coordinator, main, entry_id):
+        super().__init__(coordinator, main, entry_id)
+        self._attr_unique_id = f"mc_{entry_id}_server_installed_version"
+
+    @property
+    def native_value(self):
+        return self.coordinator.data.get("installed")
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.data.get("installed") is not None
+
+
+class MeshCentralLatestVersionSensor(_ServerBase):
+    """Latest MeshCentral version published on npm.
+
+    Works for any server regardless of hosting or auth type — this is a
+    direct, unauthenticated check against the npm registry.
+    """
+
+    _attr_name = "Latest Available Version"
+    _attr_icon = "mdi:cloud-download-outline"
+
+    def __init__(self, coordinator, main, entry_id):
+        super().__init__(coordinator, main, entry_id)
+        self._attr_unique_id = f"mc_{entry_id}_server_latest_version"
+
+    @property
+    def native_value(self):
+        return self.coordinator.data.get("latest")
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.data.get("latest") is not None


### PR DESCRIPTION
Partial implementation of #20 — server version sensors only.

## What this adds

Two diagnostic sensors on a new synthetic "MeshCentral Server" device:

- `sensor.<name>_installed_version` — via the `serverversion` websocket action.
- `sensor.<name>_latest_available_version` — direct check against `registry.npmjs.org/meshcentral/latest`, independent of the server itself.

## Why no update/install action

Dug into MeshCentral's own source (`meshuser.js`) instead of guessing against a live server. Findings, confirmed against a real server:

- The `serverversion` and `serverupdate` actions both explicitly refuse Login Token sessions: `if (req.session.loginToken != null) return;`. Login Tokens are the `~t:...` username format this integration's README recommends for 2FA accounts — so this affects exactly the accounts most likely to use this integration securely.
- Even for regular username/password site-admins, MeshCentral's internal self-update-allowed flag (`serverSelfWriteAllowed`) is never exposed to the client at all — there's no way to read it remotely without attempting a real update and observing whether it worked.
- The server-side version-check itself shells out to `npm dist-tag ls meshcentral` on the server, not a clean REST call, so there's no lightweight generic endpoint being missed.

Given that, and per discussion on #20, we're deliberately dropping the `update` entity / install-action idea. Self-update assumes a specific hosting setup this integration must not assume, and there's no reliable generic way to expose it. Users update however they manage their own server; this just tells you whether you're behind.

## Behavior

- `installed_version`: works only for full-admin, non-Login-Token sessions. Otherwise the entity is `unavailable` (not a wrong value, no error spam) — confirmed against a live server using a Login Token.
- `latest_available_version`: always works, any server, any hosting.
- Slow 6h poll — versions don't change often.

## Still open on #20

Device/mesh/account count sensors and backup status — separate, smaller follow-up since they don't hit any of the above limitations (confirmed `meshes`/`users`/`nodes` actions work fine for any session type).