### PR TITLE
Add options flow: configurable poll intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ If your server uses this, you will see an auth failure even with correct usernam
 
 If MeshCentral runs behind a reverse proxy (Nginx, Cloudflare Tunnel) with `tlsOffload: true`, set **Use SSL = off** and point directly at the internal plain HTTP port — even if that port is 443. The server accepts plain HTTP/WS on that port while the proxy handles TLS externally.
 
+### Poll intervals
+
+The device list updates instantly via WebSocket push — polling is just the fallback for missed events, plus the separate hardware (`getsysinfo`) poll. Both default to 5 minutes and can be changed under **Settings → Devices & Services → MeshCentral → Configure**, without needing to remove and re-add the integration.
+
 ## How it works
 
 The integration uses two mechanisms in parallel:

--- a/custom_components/meshcentral/__init__.py
+++ b/custom_components/meshcentral/__init__.py
@@ -39,7 +39,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not hass.services.has_service(DOMAIN, "run_command"):
         async_register_services(hass)
 
+    # Reload the entry whenever its options change (e.g. poll interval)
+    entry.async_on_unload(entry.add_update_listener(async_update_listener))
+
     return True
+
+
+async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when its options are updated."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/meshcentral/config_flow.py
+++ b/custom_components/meshcentral/config_flow.py
@@ -6,11 +6,22 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.core import callback
 
 from .client import MeshCentralClient
-from .const import CONF_LOGIN_KEY, CONF_USE_SSL, CONF_VERIFY_SSL, DEFAULT_PORT, DOMAIN
+from .const import (
+    CONF_HW_SCAN_INTERVAL,
+    CONF_LOGIN_KEY,
+    CONF_MAIN_SCAN_INTERVAL,
+    CONF_USE_SSL,
+    CONF_VERIFY_SSL,
+    DEFAULT_HW_SCAN_INTERVAL,
+    DEFAULT_MAIN_SCAN_INTERVAL,
+    DEFAULT_PORT,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +42,11 @@ class MeshCentralConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for MeshCentral."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry) -> MeshCentralOptionsFlow:
+        return MeshCentralOptionsFlow(config_entry)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -73,3 +89,35 @@ class MeshCentralConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=STEP_USER_SCHEMA,
             errors=errors,
         )
+
+
+class MeshCentralOptionsFlow(OptionsFlow):
+    """Options flow: let the user tune the poll intervals.
+
+    self.config_entry is provided automatically by the base OptionsFlow
+    class (HA 2024.12+) — no need to store it ourselves.
+    """
+
+    def __init__(self, config_entry) -> None:
+        pass
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        current = self.config_entry.options
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_MAIN_SCAN_INTERVAL,
+                    default=current.get(CONF_MAIN_SCAN_INTERVAL, DEFAULT_MAIN_SCAN_INTERVAL),
+                ): vol.All(int, vol.Range(min=1, max=60)),
+                vol.Optional(
+                    CONF_HW_SCAN_INTERVAL,
+                    default=current.get(CONF_HW_SCAN_INTERVAL, DEFAULT_HW_SCAN_INTERVAL),
+                ): vol.All(int, vol.Range(min=1, max=60)),
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/meshcentral/const.py
+++ b/custom_components/meshcentral/const.py
@@ -9,7 +9,12 @@ CONF_LOGIN_KEY = "login_key"
 DEFAULT_PORT = 443
 DEFAULT_USE_SSL = False
 DEFAULT_VERIFY_SSL = False
-DEFAULT_SCAN_INTERVAL = 30
+
+# Options flow keys for configurable poll intervals (in minutes)
+CONF_MAIN_SCAN_INTERVAL = "main_scan_interval"
+CONF_HW_SCAN_INTERVAL = "hw_scan_interval"
+DEFAULT_MAIN_SCAN_INTERVAL = 5  # minutes — fallback poll behind the WS push
+DEFAULT_HW_SCAN_INTERVAL = 5  # minutes — getsysinfo poll for hardware sensors
 
 # Device attributes
 ATTR_NODE_ID = "node_id"

--- a/custom_components/meshcentral/coordinator.py
+++ b/custom_components/meshcentral/coordinator.py
@@ -14,10 +14,12 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .client import MeshCentralClient
 from .const import (
+    CONF_HW_SCAN_INTERVAL,
     CONF_LOGIN_KEY,
+    CONF_MAIN_SCAN_INTERVAL,
     CONF_USE_SSL,
     CONF_VERIFY_SSL,
-    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_MAIN_SCAN_INTERVAL,
     DOMAIN,
 )
 
@@ -35,11 +37,12 @@ class MeshCentralCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        minutes = entry.options.get(CONF_MAIN_SCAN_INTERVAL, DEFAULT_MAIN_SCAN_INTERVAL)
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=300),  # fallback poll every 5 min
+            update_interval=timedelta(minutes=minutes),  # fallback poll behind WS push
         )
         self.entry = entry
         self.client = MeshCentralClient(

--- a/custom_components/meshcentral/sensor_hardware.py
+++ b/custom_components/meshcentral/sensor_hardware.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DOMAIN
+from .const import CONF_HW_SCAN_INTERVAL, DEFAULT_HW_SCAN_INTERVAL, DOMAIN
 from .coordinator import MeshCentralCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,13 +40,14 @@ def _linux_mount_slug(mount_point: str) -> str:
 
 
 class HardwareDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Coordinator that fetches getsysinfo for all online devices every 5 min."""
+    """Coordinator that fetches getsysinfo for all online devices."""
 
     def __init__(self, hass: HomeAssistant, main: MeshCentralCoordinator) -> None:
+        minutes = main.entry.options.get(CONF_HW_SCAN_INTERVAL, DEFAULT_HW_SCAN_INTERVAL)
         super().__init__(
             hass, _LOGGER,
             name=f"{DOMAIN}_hardware",
-            update_interval=timedelta(minutes=5),
+            update_interval=timedelta(minutes=minutes),
         )
         self._main = main
 

--- a/custom_components/meshcentral/strings.json
+++ b/custom_components/meshcentral/strings.json
@@ -25,5 +25,17 @@
     "abort": {
       "already_configured": "This MeshCentral server is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "MeshCentral poll intervals",
+        "description": "The device list also updates instantly via WebSocket push — these intervals only control the fallback poll and the hardware (getsysinfo) poll.",
+        "data": {
+          "main_scan_interval": "Main fallback poll interval (minutes)",
+          "hw_scan_interval": "Hardware sysinfo poll interval (minutes)"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #5

Adds a Configure dialog (Settings → Devices & Services → MeshCentral → Configure) with two fields:

- **Main fallback poll interval** (minutes, default 5) — the device list already updates instantly via WebSocket push; this is just the fallback poll in case events are missed.
- **Hardware sysinfo poll interval** (minutes, default 5).

Changing either reloads the config entry automatically (`add_update_listener`) — no need to remove/re-add the integration.

Also cleaned up `DEFAULT_SCAN_INTERVAL`, which was imported in `coordinator.py` but never actually used (the real interval was separately hardcoded to `timedelta(seconds=300)`).