### PR TITLE
Add device/mesh/account count sensors

### DIFF
--- a/custom_components/meshcentral/__init__.py
+++ b/custom_components/meshcentral/__init__.py
@@ -58,6 +58,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.async_shutdown()
         hass.data[DOMAIN].pop(f"{entry.entry_id}_hw", None)
         hass.data[DOMAIN].pop(f"{entry.entry_id}_serverversion", None)
+        hass.data[DOMAIN].pop(f"{entry.entry_id}_serverstats", None)
     return unload_ok
 
 

--- a/custom_components/meshcentral/client.py
+++ b/custom_components/meshcentral/client.py
@@ -177,6 +177,21 @@ class MeshCentralClient:
             return []
         return result.get("meshes", [])
 
+    async def get_users(self) -> list[dict]:
+        """Return all user accounts on the server.
+
+        Requires site-admin rights. Unlike serverversion/serverupdate, this
+        works fine for Login Token sessions too — confirmed against a live
+        server.
+        """
+        result = await self._send_recv(
+            {"action": "users", "responseid": "ha-users"},
+            "users",
+        )
+        if result is None:
+            return []
+        return result.get("users", [])
+
     async def get_server_version_tags(self) -> dict | None:
         """Return the server's own version info, if this session is allowed to.
 

--- a/custom_components/meshcentral/sensor.py
+++ b/custom_components/meshcentral/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, POWER_STATE_MAP, POWER_STATE_UNKNOWN
 from .coordinator import MeshCentralCoordinator
 from .sensor_hardware import HardwareDataCoordinator, async_setup_hardware_entities
+from .sensor_serverstats import async_setup_server_stats_entities
 from .sensor_serverversion import async_setup_server_version_entities
 
 
@@ -45,6 +46,9 @@ async def async_setup_entry(
 
     # Server-level version sensors (installed / latest available)
     await async_setup_server_version_entities(hass, entry, coordinator, async_add_entities)
+
+    # Server-level count sensors (devices online/offline, meshes, accounts)
+    await async_setup_server_stats_entities(hass, entry, coordinator, async_add_entities)
 
 
 class _Base(CoordinatorEntity[MeshCentralCoordinator], SensorEntity):

--- a/custom_components/meshcentral/sensor_serverstats.py
+++ b/custom_components/meshcentral/sensor_serverstats.py
@@ -1,0 +1,162 @@
+"""Server-wide count sensors: devices online/offline, meshes, accounts."""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+
+from .const import DOMAIN
+from .coordinator import MeshCentralCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Meshes/accounts change rarely - poll on a slow, separate interval so this
+# never adds load to the real-time device polling.
+STATS_POLL_INTERVAL = timedelta(minutes=15)
+
+
+class ServerStatsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Polls mesh (device group) and user account counts."""
+
+    def __init__(self, hass: HomeAssistant, main: MeshCentralCoordinator) -> None:
+        super().__init__(
+            hass, _LOGGER,
+            name=f"{DOMAIN}_serverstats",
+            update_interval=STATS_POLL_INTERVAL,
+        )
+        self._main = main
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        meshes = await self._main.client.get_device_groups()
+        users = await self._main.client.get_users()
+        return {"mesh_count": len(meshes), "account_count": len(users)}
+
+
+async def async_setup_server_stats_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    main: MeshCentralCoordinator,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = ServerStatsCoordinator(hass, main)
+    await coordinator.async_config_entry_first_refresh()
+    hass.data[DOMAIN][f"{entry.entry_id}_serverstats"] = coordinator
+
+    async_add_entities([
+        MeshCentralDevicesOnlineSensor(main, entry.entry_id),
+        MeshCentralDevicesOfflineSensor(main, entry.entry_id),
+        MeshCentralDevicesTotalSensor(main, entry.entry_id),
+        MeshCentralMeshCountSensor(coordinator, main, entry.entry_id),
+        MeshCentralAccountCountSensor(coordinator, main, entry.entry_id),
+    ])
+
+
+class _ServerDeviceMixin:
+    """Shared device_info: groups these on the synthetic 'MeshCentral Server' device."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:server-network"
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, f"{self._entry_id}_server")},
+            "name": "MeshCentral Server",
+            "manufacturer": "MeshCentral",
+            "configuration_url": self._main.client.base_url,
+        }
+
+
+class _MainCoordinatorBase(_ServerDeviceMixin, CoordinatorEntity[MeshCentralCoordinator], SensorEntity):
+    """Base for the three device-count sensors — reuses the main coordinator
+    directly so counts update instantly via the same WebSocket push the
+    per-device entities already use, with no extra polling.
+    """
+
+    def __init__(self, main: MeshCentralCoordinator, entry_id: str) -> None:
+        super().__init__(main)
+        self._main = main
+        self._entry_id = entry_id
+
+
+class MeshCentralDevicesOnlineSensor(_MainCoordinatorBase):
+    _attr_name = "Devices Online"
+    _attr_icon = "mdi:lan-connect"
+
+    def __init__(self, main, entry_id):
+        super().__init__(main, entry_id)
+        self._attr_unique_id = f"mc_{entry_id}_server_devices_online"
+
+    @property
+    def native_value(self):
+        return sum(1 for n in self._main.data.values() if n.get("conn", 0) == 1)
+
+
+class MeshCentralDevicesOfflineSensor(_MainCoordinatorBase):
+    _attr_name = "Devices Offline"
+    _attr_icon = "mdi:lan-disconnect"
+
+    def __init__(self, main, entry_id):
+        super().__init__(main, entry_id)
+        self._attr_unique_id = f"mc_{entry_id}_server_devices_offline"
+
+    @property
+    def native_value(self):
+        return sum(1 for n in self._main.data.values() if n.get("conn", 0) != 1)
+
+
+class MeshCentralDevicesTotalSensor(_MainCoordinatorBase):
+    _attr_name = "Devices Total"
+    _attr_icon = "mdi:devices"
+
+    def __init__(self, main, entry_id):
+        super().__init__(main, entry_id)
+        self._attr_unique_id = f"mc_{entry_id}_server_devices_total"
+
+    @property
+    def native_value(self):
+        return len(self._main.data)
+
+
+class _StatsCoordinatorBase(_ServerDeviceMixin, CoordinatorEntity[ServerStatsCoordinator], SensorEntity):
+    """Base for the slow-polled mesh/account count sensors."""
+
+    def __init__(self, coordinator: ServerStatsCoordinator, main: MeshCentralCoordinator, entry_id: str) -> None:
+        super().__init__(coordinator)
+        self._main = main
+        self._entry_id = entry_id
+
+
+class MeshCentralMeshCountSensor(_StatsCoordinatorBase):
+    _attr_name = "Device Groups"
+    _attr_icon = "mdi:folder-network"
+
+    def __init__(self, coordinator, main, entry_id):
+        super().__init__(coordinator, main, entry_id)
+        self._attr_unique_id = f"mc_{entry_id}_server_mesh_count"
+
+    @property
+    def native_value(self):
+        return self.coordinator.data.get("mesh_count")
+
+
+class MeshCentralAccountCountSensor(_StatsCoordinatorBase):
+    _attr_name = "User Accounts"
+    _attr_icon = "mdi:account-multiple"
+
+    def __init__(self, coordinator, main, entry_id):
+        super().__init__(coordinator, main, entry_id)
+        self._attr_unique_id = f"mc_{entry_id}_server_account_count"
+
+    @property
+    def native_value(self):
+        return self.coordinator.data.get("account_count")


### PR DESCRIPTION
Part of #20.

Adds five diagnostic sensors on the "MeshCentral Server" device (introduced in #21):

- `sensor.<name>_devices_online` / `_devices_offline` / `_devices_total` — derived live from the main coordinator's existing data (no extra polling, updates instantly via the same WS push the per-device entities use).
- `sensor.<name>_device_groups` — mesh count, via the existing `meshes` action.
- `sensor.<name>_user_accounts` — account count, via a new `users` action in `client.py`.

Confirmed against a live server (with a Login Token session, same as the earlier #20 findings) that `meshes` and `users` work fine — unlike `serverversion`/`serverupdate`, these aren't blocked for that auth type.

Mesh/account counts poll every 15 minutes (separate coordinator, changes rarely); device counts don't need their own poll at all.

**Not included**: active session count. Went looking for it as part of this — the only place MeshCentral's source exposes session counts is inside optional admin-configured footer/title placeholder strings (`{{connectedusers}}` etc.), which isn't a queryable action, so there's nothing reliable to poll generically.

With this, #20 is fully addressed except backup status, which needs more investigation.